### PR TITLE
NametagGroup: Clear m_chat_pages when not needed.

### DIFF
--- a/libotp/NametagGroup.py
+++ b/libotp/NametagGroup.py
@@ -370,6 +370,8 @@ class NametagGroup:
 
         if must_split:
             self.m_chat_pages = chat.split('\x07')
+        else:
+            self.m_chat_pages = []
 
         if self.m_chat_flags & CFTimeout and self.m_stomp_time < now:
             timeout = len(chat) * 0.5


### PR DESCRIPTION
In Toontown Online, there is a condition check in DistributedToon and DistributedSuit (specifically `playCurrentDialogue`) where it checks if either a list of chat pages exists, or a chat string is currently being stomped (delayed):
```python
if self.nametag.getNumChatPages() > 0:
    self.playDialogueForString(self.nametag.getChat())
    if self.soundChatBubble != None:
        base.playSfx(self.soundChatBubble, node=self)
elif self.nametag.getChatStomp() > 0:
    self.playDialogueForString(self.nametag.getStompText(), self.nametag.getStompDelay())
```
But there is an issue where the said list exists while a string is stomped, causing a dialog sound effect (meowing, barking, quacking, etc.) to play before a stomped string shows up in-game.

This PR remedies this issue by clearing m_chat_pages list back to an empty list, so the condition check could work more properly, and behaves more like the original Disney version.

This change is specifically for Toontown projects, and therefore should not effect POTCO projects in any way (correct me if I'm wrong).