### PR TITLE
NametagGroup: Clear stomp index on clearChat

### DIFF
--- a/libotp/NametagGroup.py
+++ b/libotp/NametagGroup.py
@@ -366,6 +366,7 @@ class NametagGroup:
 
         else:
             self.m_chat_flags = 0
+            self.m_chat_stomp = 0
             must_split = False
 
         if must_split:


### PR DESCRIPTION
This PR fixes an issue where the next `setChat` call gets stomped upon clearing chat.

(This is most noticeable during the [Toon-torial](https://youtu.be/3oEqxeglN9E) portion on Toontown Online since it makes heavy use of `setChat` and `clearChat` calls between dialogs.)